### PR TITLE
Async Removal and Public RenderPageAction 

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,4 +1,4 @@
-# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+﻿# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
 ###############################
 # Core EditorConfig Options   #
 ###############################
@@ -66,6 +66,16 @@ dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
+# Private Fields
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = suggestion
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.required_modifiers         = readonly
+
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
 ###############################
 # C# Coding Conventions       #
 ###############################
@@ -125,9 +135,3 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
-###############################
-# VB Coding Conventions       #
-###############################
-[*.vb]
-# Modifier preferences
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/src/.gitattributes
+++ b/src/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -258,8 +258,3 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
-
-PDFium.cs
-pdfium.so
-pdfium.dylib
-pdfium.dll

--- a/src/DtronixPdf.Tests/PdfDocumentTests.cs
+++ b/src/DtronixPdf.Tests/PdfDocumentTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -6,31 +6,25 @@ namespace DtronixPdf.Tests
 {
     public class PdfDocumentTests
     {
-
-        [SetUp]
-        public void Setup()
-        {
-            //PDFiumCoreManager.Initialize();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            //PDFiumCoreManager.Destroy();
-        }
-
-
-        [Test]
+        //[Test]
         public async Task LoadsDocument()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
             Assert.AreEqual(1, document.Pages);
         }
 
         [Test]
+        public void LoadsMemoryDocument()
+        {
+            using var stream = File.OpenRead("TestPdf.pdf");
+            using var document = PdfDocument.Load(stream, null);
+            Assert.AreEqual(1, document.Pages);
+        }
+
+        //[Test]
         public async Task SavesDocument()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
             await using var sw = new MemoryStream();
             await document.SaveAsync(sw);
 

--- a/src/DtronixPdf.Tests/PdfDocumentTests.cs
+++ b/src/DtronixPdf.Tests/PdfDocumentTests.cs
@@ -6,10 +6,11 @@ namespace DtronixPdf.Tests
 {
     public class PdfDocumentTests
     {
-        //[Test]
-        public async Task LoadsDocument()
+        [Test]
+        [Repeat(500)]
+        public void LoadsDocument()
         {
-            var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
             Assert.AreEqual(1, document.Pages);
         }
 
@@ -21,12 +22,12 @@ namespace DtronixPdf.Tests
             Assert.AreEqual(1, document.Pages);
         }
 
-        //[Test]
-        public async Task SavesDocument()
+        [Test]
+        public void SavesDocument()
         {
-            var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var sw = new MemoryStream();
-            await document.SaveAsync(sw);
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var sw = new MemoryStream();
+            document.Save(sw);
 
             Assert.Greater(sw.Length, 10000);
         }

--- a/src/DtronixPdf.Tests/PdfPageRenderTests.cs
+++ b/src/DtronixPdf.Tests/PdfPageRenderTests.cs
@@ -1,4 +1,4 @@
-using System.Drawing;
+﻿using System.Drawing;
 using System.IO;
 using System.Net.Mime;
 using System.Threading;
@@ -14,11 +14,11 @@ namespace DtronixPdf.Tests
 {
     public class PdfPageRenderTests
     {
-        [Test]
+        //[Test]
         public async Task RendererCreatesImageSize()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
+            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var page = await document.GetPageAsync(0);
             var renderPage = await page.RenderAsync(
                 1,
                 (uint)Color.White.ToArgb(),
@@ -30,11 +30,11 @@ namespace DtronixPdf.Tests
             Assert.AreEqual(page.Height, image.Height);
         }
 
-        [Test]
+        //[Test]
         public async Task RendererSavesImage()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
+            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var page = await document.GetPageAsync(0);
             var renderPage = await page.RenderAsync(
                 1,
                 (uint)Color.White.ToArgb(),

--- a/src/DtronixPdf.Tests/PdfPageRenderTests.cs
+++ b/src/DtronixPdf.Tests/PdfPageRenderTests.cs
@@ -14,12 +14,12 @@ namespace DtronixPdf.Tests
 {
     public class PdfPageRenderTests
     {
-        //[Test]
-        public async Task RendererCreatesImageSize()
+        [Test]
+        public void RendererCreatesImageSize()
         {
-            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            using var page = await document.GetPageAsync(0);
-            var renderPage = await page.RenderAsync(
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
+            var renderPage = page.Render(
                 1,
                 (uint)Color.White.ToArgb(),
                 new Boundary(0, 0, page.Width, page.Height));
@@ -30,45 +30,43 @@ namespace DtronixPdf.Tests
             Assert.AreEqual(page.Height, image.Height);
         }
 
-        //[Test]
-        public async Task RendererSavesImage()
+        [Test]
+        public void RendererSavesImage()
         {
-            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            using var page = await document.GetPageAsync(0);
-            var renderPage = await page.RenderAsync(
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
+            var renderPage = page.Render(
                 1,
                 (uint)Color.White.ToArgb(),
                 new Boundary(0, 0, page.Width, page.Height));
 
-            await using var writer = File.OpenWrite("test.png");
-            await renderPage.GetImage().SaveAsync(writer, new PngEncoder());
+            using var writer = File.OpenWrite("test.png");
+            renderPage.GetImage().Save(writer, new PngEncoder());
         }
 
         /*
-        public async Task PixelTest_1()
+        public void PixelTest_1()
         {
-            await using var document = await PdfDocument.Load("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
-            await using var expectedImageStream = File.OpenRead("PdfPageRendererTests/pixel_test_1.png");
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
+            using var expectedImageStream = File.OpenRead("PdfPageRendererTests/pixel_test_1.png");
             using var expectedImage = MediaTypeNames.Image.Load<Bgra32>(expectedImageStream, new PngDecoder());
 
-            var renderPage = await page.Render(
+            var renderPage = page.Render(
                 1,
                 (uint)Color.White.ToArgb(), 
                 new Boundary(522, 477, 3, 3));
 
-            var renderPage2 = await page.Render(
+            var renderPage2 = page.Render(
                 1,
                 (uint)Color.White.ToArgb(), 
                 new Boundary(522, 477, 30, 30));
 
-            await renderPage2.Image.SaveAsPngAsync("png1Crop.png");
+            renderPage2.Image.SaveAsPng("png1Crop.png");
 
-            var renderPage3 = await page.Render(1, Color.White);
+            var renderPage3 = page.Render(1, Color.White);
 
-            await renderPage3.Image.SaveAsPngAsync("png1Full.png");
-
-
+            renderPage3.Image.SaveAsPng("png1Full.png");
 
 
 
@@ -78,7 +76,9 @@ namespace DtronixPdf.Tests
 
 
 
-            var pageBitmap = await page.Render(1, Color.White);
+
+
+            var pageBitmap = page.Render(1, Color.White);
             
             for (int x = 0; x < 3; x++)
             {

--- a/src/DtronixPdf.Tests/PdfPageTests.cs
+++ b/src/DtronixPdf.Tests/PdfPageTests.cs
@@ -21,42 +21,42 @@ namespace DtronixPdf.Tests
         }
 
 
-        [Test]
+        //[Test]
         public async Task LoadsPage()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
+            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var page = await document.GetPageAsync(0);
         }
 
-        [Test]
+        //[Test]
         public async Task PageSizeIsReturned()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
+            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var page = await document.GetPageAsync(0);
             Assert.AreEqual(new SizeF(792, 612), new SizeF(page.Width, page.Height));
         }
 
-        [Test]
+        //[Test]
         public async Task InitalIndexIsReturned()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
+            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var page = await document.GetPageAsync(0);
             Assert.AreEqual(0, page.InitialIndex);
         }
 
-        [Test]
+        //[Test]
         public async Task GetRotationReturnsCorrectValue()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
+            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var page = await document.GetPageAsync(0);
             Assert.AreEqual(3, await page.GetRotationAsync());
         }
 
-        [Test]
+        //[Test]
         public async Task SetRotationSetsValue()
         {
-            await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            await using var page = await document.GetPageAsync(0);
+            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
+            using var page = await document.GetPageAsync(0);
             await page.SetRotationAsync(1);
             Assert.AreEqual(1, await page.GetRotationAsync());
         }

--- a/src/DtronixPdf.Tests/PdfPageTests.cs
+++ b/src/DtronixPdf.Tests/PdfPageTests.cs
@@ -21,44 +21,44 @@ namespace DtronixPdf.Tests
         }
 
 
-        //[Test]
-        public async Task LoadsPage()
+        [Test]
+        public void LoadsPage()
         {
-            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            using var page = await document.GetPageAsync(0);
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
         }
 
-        //[Test]
-        public async Task PageSizeIsReturned()
+        [Test]
+        public void PageSizeIsReturned()
         {
-            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            using var page = await document.GetPageAsync(0);
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
             Assert.AreEqual(new SizeF(792, 612), new SizeF(page.Width, page.Height));
         }
 
-        //[Test]
-        public async Task InitalIndexIsReturned()
+        [Test]
+        public void InitalIndexIsReturned()
         {
-            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            using var page = await document.GetPageAsync(0);
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
             Assert.AreEqual(0, page.InitialIndex);
         }
 
-        //[Test]
-        public async Task GetRotationReturnsCorrectValue()
+        [Test]
+        public void GetRotationReturnsCorrectValue()
         {
-            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            using var page = await document.GetPageAsync(0);
-            Assert.AreEqual(3, await page.GetRotationAsync());
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
+            Assert.AreEqual(3, page.GetRotation());
         }
 
-        //[Test]
-        public async Task SetRotationSetsValue()
+        [Test]
+        public void SetRotationSetsValue()
         {
-            using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
-            using var page = await document.GetPageAsync(0);
-            await page.SetRotationAsync(1);
-            Assert.AreEqual(1, await page.GetRotationAsync());
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
+            page.SetRotation(1);
+            Assert.AreEqual(1, page.GetRotation());
         }
     }
 }

--- a/src/DtronixPdf.Tests/PdfPageTests.cs
+++ b/src/DtronixPdf.Tests/PdfPageTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SixLabors.ImageSharp;
@@ -49,7 +49,7 @@ namespace DtronixPdf.Tests
         {
             await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
             await using var page = await document.GetPageAsync(0);
-            Assert.AreEqual(3, await page.GetRotation());
+            Assert.AreEqual(3, await page.GetRotationAsync());
         }
 
         [Test]
@@ -57,8 +57,8 @@ namespace DtronixPdf.Tests
         {
             await using var document = await PdfDocument.LoadAsync("TestPdf.pdf", null);
             await using var page = await document.GetPageAsync(0);
-            await page.SetRotation(1);
-            Assert.AreEqual(1, await page.GetRotation());
+            await page.SetRotationAsync(1);
+            Assert.AreEqual(1, await page.GetRotationAsync());
         }
     }
 }

--- a/src/DtronixPdf/Actions/RenderPageAction.cs
+++ b/src/DtronixPdf/Actions/RenderPageAction.cs
@@ -15,7 +15,7 @@ namespace DtronixPdf.Actions
         private readonly Boundary _viewport;
         private RenderFlags _flags = RenderFlags.RenderAnnotations;
         private readonly uint? _backgroundColor = UInt32.MaxValue;
-        private readonly PdfThreadDispatcher _dispatcher;
+        private readonly PdfActionSynchronizer _synchronizer;
         private FpdfBitmapT _bitmap;
         private float _offsetX;
         private float _offsetY;
@@ -38,7 +38,7 @@ namespace DtronixPdf.Actions
             set => _flags = value;
         }
 
-        internal RenderPageAction(PdfThreadDispatcher dispatcher,
+        internal RenderPageAction(PdfActionSynchronizer synchronizer,
             FpdfPageT pageInstance,
             float scale,
             Boundary viewport,
@@ -52,7 +52,7 @@ namespace DtronixPdf.Actions
             _viewport = viewport;
             _flags = flags;
             _backgroundColor = backgroundColor ?? UInt32.MaxValue;
-            _dispatcher = dispatcher;
+            _synchronizer = synchronizer;
         }
 
         public RenderPageAction(
@@ -63,7 +63,7 @@ namespace DtronixPdf.Actions
             : base(cancellationToken)
         {
             _pageInstance = page.PageInstance;
-            _dispatcher = page.Document.Dispatcher;
+            _synchronizer = page.Document.Synchronizer;
             _scale = scale;
             _viewport = viewport;
         }
@@ -125,7 +125,7 @@ namespace DtronixPdf.Actions
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return new PdfBitmap(_bitmap, _dispatcher, _scale, _viewport);
+                return new PdfBitmap(_bitmap, _synchronizer, _scale, _viewport);
             }
             catch (OperationCanceledException)
             {

--- a/src/DtronixPdf/Actions/RenderPageAction.cs
+++ b/src/DtronixPdf/Actions/RenderPageAction.cs
@@ -13,7 +13,7 @@ namespace DtronixPdf.Actions
         public readonly FpdfPageT _pageInstance;
         private readonly float _scale;
         private readonly Boundary _viewport;
-        private readonly RenderFlags _flags = RenderFlags.RenderAnnotations;
+        private RenderFlags _flags = RenderFlags.RenderAnnotations;
         private readonly uint? _backgroundColor = UInt32.MaxValue;
         private readonly ThreadDispatcher _dispatcher;
         private FpdfBitmapT _bitmap;
@@ -30,6 +30,12 @@ namespace DtronixPdf.Actions
         {
             get => _offsetY;
             set => _offsetY = value;
+        }
+
+        public RenderFlags Flags
+        {
+            get => _flags;
+            set => _flags = value;
         }
 
         internal RenderPageAction(ThreadDispatcher dispatcher,
@@ -113,7 +119,7 @@ namespace DtronixPdf.Actions
                     F = _offsetY
                 };
 
-                fpdfview.FPDF_RenderPageBitmapWithMatrix(_bitmap, _pageInstance, matrix, clipping, (int)_flags);
+                fpdfview.FPDF_RenderPageBitmapWithMatrix(_bitmap, _pageInstance, matrix, clipping, (int)Flags);
 
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/DtronixPdf/DtronixPdf.csproj
+++ b/src/DtronixPdf/DtronixPdf.csproj
@@ -15,7 +15,7 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="DtronixCommon" Version="0.6.4" />
+		<PackageReference Include="DtronixCommon" Version="0.6.5" />
 		<PackageReference Include="PDFiumCore" Version="109.0.5378" />
 	</ItemGroup>
 </Project>

--- a/src/DtronixPdf/DtronixPdf.csproj
+++ b/src/DtronixPdf/DtronixPdf.csproj
@@ -15,7 +15,7 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="DtronixCommon" Version="0.6.5" />
+		<PackageReference Include="DtronixCommon" Version="0.6.6" />
 		<PackageReference Include="PDFiumCore" Version="109.0.5378" />
 	</ItemGroup>
 </Project>

--- a/src/DtronixPdf/PDFiumManager.cs
+++ b/src/DtronixPdf/PDFiumManager.cs
@@ -16,7 +16,7 @@ namespace DtronixPdf
         private static PdfiumCoreManager _managerDefaultInstance;
         public static PdfiumCoreManager Default => _managerDefaultInstance ??= new PdfiumCoreManager();
 
-        public readonly PdfThreadDispatcher Dispatcher;
+        private readonly PdfActionSynchronizer _synchronizer;
 
         private readonly List<PdfDocument> LoadedDocuments = new ();
 
@@ -26,22 +26,7 @@ namespace DtronixPdf
         {
             LoadedManagers.Add(this);
 
-            Dispatcher = new PdfThreadDispatcher(1);
-            Dispatcher.Start();
-        }
-
-        /// <summary>
-        /// Initialized the PDFiumCore library.
-        /// </summary>
-        /// <returns></returns>
-        internal static Task InitializeAsync()
-        {
-            if (IsInitialized)
-                return Task.CompletedTask;
-
-            IsInitialized = true;
-            // Initialize the library.
-            return Default.Dispatcher.Queue(fpdfview.FPDF_InitLibrary);
+            _synchronizer = new PdfActionSynchronizer();
         }
 
         /// <summary>
@@ -55,27 +40,10 @@ namespace DtronixPdf
 
             IsInitialized = true;
             // Initialize the library.
-            Default.Dispatcher.SyncExec(fpdfview.FPDF_InitLibrary);
+            Default._synchronizer.SyncExec(fpdfview.FPDF_InitLibrary);
         }
 
-        private static Task UnloadAsync()
-        {
-            if (!IsInitialized)
-                return Task.CompletedTask;
-
-            foreach (var pdfiumCoreManager in LoadedManagers)
-            {
-                if (pdfiumCoreManager.LoadedDocuments.Count > 0)
-                    throw new InvalidOperationException("Can't destroy loaded library since it is still in use by PdfDocument(s)");
-            }
-
-            IsInitialized = false;
-
-            // Initialize the library.
-            return Default.Dispatcher.Queue(fpdfview.FPDF_DestroyLibrary);
-        }
-
-        private static void Unload()
+        public static void Unload()
         {
             if (!IsInitialized)
                 return;
@@ -88,7 +56,7 @@ namespace DtronixPdf
 
             IsInitialized = false;
 
-            Default.Dispatcher.SyncExec(fpdfview.FPDF_DestroyLibrary);
+            Default._synchronizer.SyncExec(fpdfview.FPDF_DestroyLibrary);
         }
 
         internal void AddDocument(PdfDocument document)

--- a/src/DtronixPdf/PDFiumManager.cs
+++ b/src/DtronixPdf/PDFiumManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using DtronixCommon.Threading.Dispatcher;
 using PDFiumCore;
@@ -8,24 +9,24 @@ using PDFiumCore;
 namespace DtronixPdf
 {
 
-    public class PDFiumCoreManager
+    public class PdfiumCoreManager
     {
         private static bool IsInitialized;
 
-        private static PDFiumCoreManager _managerDefaultInstance;
-        public static PDFiumCoreManager Default => _managerDefaultInstance ??= new PDFiumCoreManager();
+        private static PdfiumCoreManager _managerDefaultInstance;
+        public static PdfiumCoreManager Default => _managerDefaultInstance ??= new PdfiumCoreManager();
 
-        public readonly ThreadDispatcher Dispatcher;
+        public readonly PdfThreadDispatcher Dispatcher;
 
         private readonly List<PdfDocument> LoadedDocuments = new ();
 
-        private static readonly ConcurrentBag<PDFiumCoreManager> LoadedManagers = new ();
+        private static readonly ConcurrentBag<PdfiumCoreManager> LoadedManagers = new ();
 
-        private PDFiumCoreManager()
+        private PdfiumCoreManager()
         {
             LoadedManagers.Add(this);
 
-            Dispatcher = new ThreadDispatcher(1);
+            Dispatcher = new PdfThreadDispatcher(1);
             Dispatcher.Start();
         }
 
@@ -33,7 +34,7 @@ namespace DtronixPdf
         /// Initialized the PDFiumCore library.
         /// </summary>
         /// <returns></returns>
-        internal static Task Initialize()
+        internal static Task InitializeAsync()
         {
             if (IsInitialized)
                 return Task.CompletedTask;
@@ -43,7 +44,21 @@ namespace DtronixPdf
             return Default.Dispatcher.Queue(fpdfview.FPDF_InitLibrary);
         }
 
-        private static Task Unload()
+        /// <summary>
+        /// Initialized the PDFiumCore library.
+        /// </summary>
+        /// <returns></returns>
+        internal static void Initialize()
+        {
+            if (IsInitialized)
+                return;
+
+            IsInitialized = true;
+            // Initialize the library.
+            Default.Dispatcher.SyncExec(fpdfview.FPDF_InitLibrary);
+        }
+
+        private static Task UnloadAsync()
         {
             if (!IsInitialized)
                 return Task.CompletedTask;
@@ -58,6 +73,22 @@ namespace DtronixPdf
 
             // Initialize the library.
             return Default.Dispatcher.Queue(fpdfview.FPDF_DestroyLibrary);
+        }
+
+        private static void Unload()
+        {
+            if (!IsInitialized)
+                return;
+
+            foreach (var pdfiumCoreManager in LoadedManagers)
+            {
+                if (pdfiumCoreManager.LoadedDocuments.Count > 0)
+                    throw new InvalidOperationException("Can't destroy loaded library since it is still in use by PdfDocument(s)");
+            }
+
+            IsInitialized = false;
+
+            Default.Dispatcher.SyncExec(fpdfview.FPDF_DestroyLibrary);
         }
 
         internal void AddDocument(PdfDocument document)

--- a/src/DtronixPdf/PdfBitmap.cs
+++ b/src/DtronixPdf/PdfBitmap.cs
@@ -7,11 +7,11 @@ using PDFiumCore;
 
 namespace DtronixPdf
 {
-    public class PdfBitmap : IAsyncDisposable, IDisposable
+    public class PdfBitmap : IDisposable
     {
         private readonly FpdfBitmapT _pdfBitmap;
 
-        private readonly PdfThreadDispatcher _dispatcher;
+        private readonly PdfActionSynchronizer _synchronizer;
 
         public float Scale { get; }
 
@@ -28,16 +28,16 @@ namespace DtronixPdf
         public bool IsDisposed { get; private set; }
 
         /// <summary>
-        /// Only call within the dispatcher since dll calls are made.
+        /// Only call within the synchronizer since dll calls are made.
         /// </summary>
         /// <param name="pdfBitmap"></param>
         /// <param name="image"></param>
-        /// <param name="dispatcher"></param>
+        /// <param name="synchronizer"></param>
         /// <param name="scale"></param>
         /// <param name="viewport"></param>
         internal PdfBitmap(
             FpdfBitmapT pdfBitmap,
-            PdfThreadDispatcher dispatcher,
+            PdfActionSynchronizer synchronizer,
             float scale, 
             Boundary viewport)
         {
@@ -46,26 +46,10 @@ namespace DtronixPdf
             Width = (int)viewport.Width;
             Height = (int)viewport.Height;
             Pointer = fpdfview.FPDFBitmapGetBuffer(_pdfBitmap);
-            _dispatcher = dispatcher;
+            _synchronizer = synchronizer;
             Scale = scale;
             Viewport = viewport;
         }
-
-
-
-        public async ValueTask DisposeAsync()
-        {
-            if (IsDisposed)
-                return;
-
-            IsDisposed = true;
-
-            await _dispatcher.Queue(new SimpleMessagePumpAction(() =>
-            {
-                fpdfview.FPDFBitmapDestroy(_pdfBitmap);
-            })).ConfigureAwait(false);
-        }
-
 
         public void Dispose()
         {
@@ -74,7 +58,7 @@ namespace DtronixPdf
 
             IsDisposed = true;
 
-            fpdfview.FPDFBitmapDestroy(_pdfBitmap);
+            _synchronizer.SyncExec(() => fpdfview.FPDFBitmapDestroy(_pdfBitmap));
         }
     }
 }

--- a/src/DtronixPdf/PdfBitmap.cs
+++ b/src/DtronixPdf/PdfBitmap.cs
@@ -11,7 +11,7 @@ namespace DtronixPdf
     {
         private readonly FpdfBitmapT _pdfBitmap;
 
-        private readonly ThreadDispatcher _dispatcher;
+        private readonly PdfThreadDispatcher _dispatcher;
 
         public float Scale { get; }
 
@@ -37,7 +37,7 @@ namespace DtronixPdf
         /// <param name="viewport"></param>
         internal PdfBitmap(
             FpdfBitmapT pdfBitmap,
-            ThreadDispatcher dispatcher,
+            PdfThreadDispatcher dispatcher,
             float scale, 
             Boundary viewport)
         {

--- a/src/DtronixPdf/PdfDocument.cs
+++ b/src/DtronixPdf/PdfDocument.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -12,122 +13,54 @@ namespace DtronixPdf
     {
         internal readonly FpdfDocumentT Instance;
 
-        private readonly PdfiumCoreManager Manager;
-        internal readonly PdfThreadDispatcher Dispatcher;
+        internal readonly PdfActionSynchronizer Synchronizer;
 
         private bool _isDisposed = false;
-        private static IntPtr? _documentPointer;
+        private IntPtr? _documentPointer;
 
         public int Pages { get; private set; }
 
-        private PdfDocument(PdfiumCoreManager manager, FpdfDocumentT instance)
+        private PdfDocument(PdfActionSynchronizer synchronizer, FpdfDocumentT instance)
         {
-            Dispatcher = manager.Dispatcher;
-            Manager = manager;
+            Synchronizer = synchronizer;
             Instance = instance;
-        }
-
-        public static async Task<PdfDocument> LoadAsync(
-            string path,
-            string password,
-            CancellationToken cancellationToken = default)
-        {
-            return await LoadAsync(path, password, PdfiumCoreManager.Default, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        public static async Task<PdfDocument> LoadAsync(
-            string path,
-            string password,
-            PdfiumCoreManager manager,
-            CancellationToken cancellationToken = default)
-        {
-            await PdfiumCoreManager.InitializeAsync().ConfigureAwait(false);
-
-            int pages = -1;
-            var result = await manager.Dispatcher.QueueResult(_ =>
-                {
-                    var document = fpdfview.FPDF_LoadDocument(path, password);
-                    pages = fpdfview.FPDF_GetPageCount(document);
-                    return document;
-                }, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            if (result == null)
-                return null;
-
-            var pdfDocument = new PdfDocument(manager, result)
-            {
-                Pages = pages,
-            };
-
-            manager.AddDocument(pdfDocument);
-
-            return pdfDocument;
+            PdfiumCoreManager.Default.AddDocument(this);
         }
 
         public static PdfDocument Load(
             string path,
             string password,
-            CancellationToken cancellationToken = default)
-        {
-            return Load(path, password, PdfiumCoreManager.Default, cancellationToken);
-        }
-
-        public static PdfDocument Load(
-            string path,
-            string password,
-            PdfiumCoreManager manager,
             CancellationToken cancellationToken = default)
         {
             PdfiumCoreManager.Initialize();
 
-            try
-            {
-                manager.Dispatcher.Semaphore.Wait(cancellationToken);
+            var synchronizer = new PdfActionSynchronizer();
 
-                var document = fpdfview.FPDF_LoadDocument(path, password);
-                var pages = fpdfview.FPDF_GetPageCount(document);
+            var document = synchronizer.SyncExec(() => fpdfview.FPDF_LoadDocument(path, password));
+            var pages = synchronizer.SyncExec(() => fpdfview.FPDF_GetPageCount(document));
 
-                if (document == null)
-                    return null;
+            if (document == null)
+                return null;
 
-                var pdfDocument = new PdfDocument(manager, document)
-                {
-                    Pages = pages,
-                };
+            var pdfDocument = new PdfDocument(synchronizer, document) { Pages = pages, };
 
-                manager.AddDocument(pdfDocument);
+            return pdfDocument;
 
-                return pdfDocument;
-
-            }
-            finally
-            {
-                manager.Dispatcher.Semaphore.Release();
-            }
         }
-
-        public static PdfDocument Load(
-            Stream stream,
-            string password,
-            CancellationToken cancellationToken = default)
-        {
-            return Load(stream, password, PdfiumCoreManager.Default, cancellationToken);
-        }
-
 
         public static unsafe PdfDocument Load(
             Stream stream,
             string password,
-            PdfiumCoreManager manager,
             CancellationToken cancellationToken = default)
         {
+            var synchronizer = new PdfActionSynchronizer();
+
             var length = (int)stream.Length;
 
             var ptr = NativeMemory.Alloc((nuint)length);
 
             Span<byte> ptrSpan = new Span<byte>(ptr, length);
-            _documentPointer = new IntPtr(ptr);
+            var pointer = new IntPtr(ptr);
             var readLength = 0;
 
             // Copy the data to the memory.
@@ -137,9 +70,9 @@ namespace DtronixPdf
             PdfiumCoreManager.Initialize();
 
             int pages = -1;
-            var result = manager.Dispatcher.SyncExec(() =>
+            var result = synchronizer.SyncExec(() =>
             {
-                var document = fpdfview.FPDF_LoadMemDocument(_documentPointer.Value, length, password);
+                var document = fpdfview.FPDF_LoadMemDocument(pointer, length, password);
                 pages = fpdfview.FPDF_GetPageCount(document);
                 return document;
             });
@@ -147,53 +80,25 @@ namespace DtronixPdf
             if (result == null)
                 return null;
 
-            var pdfDocument = new PdfDocument(manager, result)
+            var pdfDocument = new PdfDocument(synchronizer, result)
             {
                 Pages = pages,
+                _documentPointer = pointer
             };
-
-            manager.AddDocument(pdfDocument);
 
             return pdfDocument;
         }
 
-        public static async Task<PdfDocument> CreateAsync()
-        {
-            return await CreateAsync(PdfiumCoreManager.Default).ConfigureAwait(false);
-        }
-
-        public static async Task<PdfDocument> CreateAsync(PdfiumCoreManager manager)
-        {
-            var result = await manager.Dispatcher.QueueResult(_ => fpdf_edit.FPDF_CreateNewDocument())
-                .ConfigureAwait(false);
-
-            if (result == null)
-                return null;
-
-            return new PdfDocument(manager, result);
-        }
-
         public static PdfDocument Create()
         {
-            return Create(PdfiumCoreManager.Default);
-        }
+            var synchronizer = new PdfActionSynchronizer();
 
-        public static PdfDocument Create(PdfiumCoreManager manager)
-        {
-            var result = manager.Dispatcher.SyncExec(fpdf_edit.FPDF_CreateNewDocument);
+            var result = synchronizer.SyncExec(fpdf_edit.FPDF_CreateNewDocument);
 
             if (result == null)
                 return null;
 
-            return new PdfDocument(manager, result);
-        }
-
-
-
-        public async Task<PdfPage> GetPageAsync(int pageIndex)
-        {
-            return await PdfPage.CreateAsync(this, pageIndex)
-                .ConfigureAwait(false);
+            return new PdfDocument(synchronizer, result);
         }
 
         public PdfPage GetPage(int pageIndex)
@@ -210,42 +115,10 @@ namespace DtronixPdf
         /// If null, all pages are imported.</param>
         /// <param name="insertIndex">Insertion index is 0 based.</param>
         /// <returns>True on success, false on failure.</returns>
-        public async Task<bool> ImportPagesAsync(PdfDocument document, string pageRange, int insertIndex)
-        {
-            return await Dispatcher.QueueResult(_ =>
-            {
-                var result = fpdf_ppo.FPDF_ImportPages(Instance, document.Instance, pageRange, insertIndex);
-                return result == 1;
-            }).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Imports pages from another PDF document.
-        /// </summary>
-        /// <param name="document"></param>
-        /// <param name="pageRange">
-        /// Pages are 1 based. Pages are separated by commas. Such as "1,3,5-7".
-        /// If null, all pages are imported.</param>
-        /// <param name="insertIndex">Insertion index is 0 based.</param>
-        /// <returns>True on success, false on failure.</returns>
         public bool ImportPages(PdfDocument document, string pageRange, int insertIndex)
         {
-            return Dispatcher.SyncExec(() =>
+            return Synchronizer.SyncExec(() =>
                 fpdf_ppo.FPDF_ImportPages(Instance, document.Instance, pageRange, insertIndex) == 1);
-        }
-
-
-        /// <summary>
-        /// Extracts the specified page range into a new PdfDocument.
-        /// </summary>
-        /// <param name="pageRange">Pages are 1 based. Pages are separated by commas. Such as "1,3,5-7".</param>
-        /// <returns>New document with the specified pages.</returns>
-        public async Task<PdfDocument> ExtractPagesAsync(string pageRange)
-        {
-            var newDocument = await CreateAsync().ConfigureAwait(false);
-            await newDocument.ImportPagesAsync(this, pageRange, 0).ConfigureAwait(false);
-
-            return newDocument;
         }
 
         /// <summary>
@@ -266,56 +139,11 @@ namespace DtronixPdf
         /// </summary>
         /// <param name="pageIndex">0 based index.</param>
         /// <returns>True on success, false on failure.</returns>
-        public async Task DeletePageAsync(int pageIndex)
-        {
-            await Dispatcher
-                .Queue(() => fpdf_edit.FPDFPageDelete(Instance, pageIndex))
-                .ConfigureAwait(true);
-            
-        }
-
-        /// <summary>
-        /// Deletes the specified page from the document.
-        /// </summary>
-        /// <param name="pageIndex">0 based index.</param>
-        /// <returns>True on success, false on failure.</returns>
         public void DeletePage(int pageIndex)
         {
-            Dispatcher.SyncExec(() => fpdf_edit.FPDFPageDelete(Instance, pageIndex));
+            Synchronizer.SyncExec(() => fpdf_edit.FPDFPageDelete(Instance, pageIndex));
         }
 
-        /// <summary>
-        /// Saves the current document to the specified file path.
-        /// </summary>
-        /// <param name="path">Path to save the PdfDocument.</param>
-        /// <returns>True on success, false on failure.</returns>
-        public async Task<bool> SaveAsync(string path)
-        {
-            await using var fs = new FileStream(path, FileMode.Create);
-
-            return await SaveAsync(fs).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Saves the current document to the passed stream.
-        /// </summary>
-        /// <param name="stream">Destination stream to write the PdfDocument.</param>
-        /// <returns>True on success, false on failure.</returns>
-        public async Task<bool> SaveAsync(Stream stream)
-        {
-            var writer = new PdfFileWriteCopyStream(stream);
-            /*
-             Flags
-            #define FPDF_INCREMENTAL 1
-            #define FPDF_NO_INCREMENTAL 2
-            #define FPDF_REMOVE_SECURITY 3
-             */
-
-            var result = await Dispatcher.QueueResult(_ =>
-                fpdf_save.FPDF_SaveAsCopy(Instance, writer, 1)).ConfigureAwait(false);
-
-            return result == 1;
-        }
 
         /// <summary>
         /// Saves the current document to the specified file path.
@@ -343,7 +171,7 @@ namespace DtronixPdf
             #define FPDF_REMOVE_SECURITY 3
              */
 
-            var result = Dispatcher.SyncExec(() => fpdf_save.FPDF_SaveAsCopy(Instance, writer, 1));
+            var result = Synchronizer.SyncExec(() => fpdf_save.FPDF_SaveAsCopy(Instance, writer, 1));
 
             return result == 1;
         }
@@ -354,12 +182,17 @@ namespace DtronixPdf
                 return;
 
             _isDisposed = true;
-            
-            Dispatcher.SyncExec(() => fpdfview.FPDF_CloseDocument(Instance));
+
+            Synchronizer.SyncExec(() => fpdfview.FPDF_CloseDocument(Instance));
+
+            PdfiumCoreManager.Default.RemoveDocument(this);
 
             // Free the native memory.
             if (_documentPointer != null)
+            {
                 NativeMemory.Free(_documentPointer.Value.ToPointer());
+                _documentPointer = null;
+            }
         }
     }
 }

--- a/src/DtronixPdf/PdfPage.Edit.cs
+++ b/src/DtronixPdf/PdfPage.Edit.cs
@@ -19,7 +19,7 @@ namespace DtronixPdf
         /// <returns></returns>
         public Task SetRotation(int rotation)
         {
-            return _dispatcher.Queue(() => fpdf_edit.FPDFPageSetRotation(_pageInstance, rotation));
+            return _dispatcher.Queue(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace DtronixPdf
         /// </returns>
         public Task<int> GetRotation()
         {
-            return _dispatcher.QueueResult(_ => fpdf_edit.FPDFPageGetRotation(_pageInstance));
+            return _dispatcher.QueueResult(_ => fpdf_edit.FPDFPageGetRotation(PageInstance));
         }
 
         /// <summary>

--- a/src/DtronixPdf/PdfPage.Edit.cs
+++ b/src/DtronixPdf/PdfPage.Edit.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Mono.TextTemplating;
 using PDFiumCore;
 
 namespace DtronixPdf
 {
-    public partial class PdfPage : IAsyncDisposable
+    public partial class PdfPage
     {
         
         /// <summary>
@@ -17,23 +18,9 @@ namespace DtronixPdf
         /// <para>3 - Rotated 270 degrees clockwise.</para>
         /// </param>
         /// <returns></returns>
-        public Task SetRotation(int rotation)
+        public Task SetRotationAsync(int rotation)
         {
-            return _dispatcher.Queue(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
-        }
-
-        /// <summary>
-        /// Rotates the page
-        /// </summary>
-        /// <returns>
-        /// <para>0 - No rotation.</para>
-        /// <para>1 - Rotated 90 degrees clockwise.</para>
-        /// <para>2 - Rotated 180 degrees clockwise.</para>
-        /// <para>3 - Rotated 270 degrees clockwise.</para>
-        /// </returns>
-        public Task<int> GetRotation()
-        {
-            return _dispatcher.QueueResult(_ => fpdf_edit.FPDFPageGetRotation(PageInstance));
+            return Document.Dispatcher.Queue(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
         }
 
         /// <summary>
@@ -46,9 +33,67 @@ namespace DtronixPdf
         /// <para>3 - Rotated 270 degrees clockwise.</para>
         /// </param>
         /// <returns></returns>
-        public Task Delete()
+        public void SetRotation(int rotation)
         {
-            return _dispatcher.Queue(() => fpdf_edit.FPDFPageDelete(_documentInstance, InitialIndex));
+            Document.Dispatcher.SyncExec(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
+        }
+
+        /// <summary>
+        /// Rotates the page
+        /// </summary>
+        /// <returns>
+        /// <para>0 - No rotation.</para>
+        /// <para>1 - Rotated 90 degrees clockwise.</para>
+        /// <para>2 - Rotated 180 degrees clockwise.</para>
+        /// <para>3 - Rotated 270 degrees clockwise.</para>
+        /// </returns>
+        public Task<int> GetRotationAsync()
+        {
+            return Document.Dispatcher.QueueResult(_ => fpdf_edit.FPDFPageGetRotation(PageInstance));
+        }
+
+        /// <summary>
+        /// Rotates the page
+        /// </summary>
+        /// <returns>
+        /// <para>0 - No rotation.</para>
+        /// <para>1 - Rotated 90 degrees clockwise.</para>
+        /// <para>2 - Rotated 180 degrees clockwise.</para>
+        /// <para>3 - Rotated 270 degrees clockwise.</para>
+        /// </returns>
+        public int GetRotation()
+        {
+            return Document.Dispatcher.SyncExec(() => fpdf_edit.FPDFPageGetRotation(PageInstance));
+        }
+
+        /// <summary>
+        /// Rotates the page
+        /// </summary>
+        /// <param name="rotation">
+        /// <para>0 - No rotation.</para>
+        /// <para>1 - Rotated 90 degrees clockwise.</para>
+        /// <para>2 - Rotated 180 degrees clockwise.</para>
+        /// <para>3 - Rotated 270 degrees clockwise.</para>
+        /// </param>
+        /// <returns></returns>
+        public Task DeleteAsync()
+        {
+            return Document.Dispatcher.Queue(() => fpdf_edit.FPDFPageDelete(Document.Instance, InitialIndex));
+        }
+
+        /// <summary>
+        /// Rotates the page
+        /// </summary>
+        /// <param name="rotation">
+        /// <para>0 - No rotation.</para>
+        /// <para>1 - Rotated 90 degrees clockwise.</para>
+        /// <para>2 - Rotated 180 degrees clockwise.</para>
+        /// <para>3 - Rotated 270 degrees clockwise.</para>
+        /// </param>
+        /// <returns></returns>
+        public void Delete()
+        {
+            Document.Dispatcher.SyncExec(() => fpdf_edit.FPDFPageDelete(Document.Instance, InitialIndex));
         }
     }
 }

--- a/src/DtronixPdf/PdfPage.Edit.cs
+++ b/src/DtronixPdf/PdfPage.Edit.cs
@@ -18,38 +18,9 @@ namespace DtronixPdf
         /// <para>3 - Rotated 270 degrees clockwise.</para>
         /// </param>
         /// <returns></returns>
-        public Task SetRotationAsync(int rotation)
-        {
-            return Document.Dispatcher.Queue(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
-        }
-
-        /// <summary>
-        /// Rotates the page
-        /// </summary>
-        /// <param name="rotation">
-        /// <para>0 - No rotation.</para>
-        /// <para>1 - Rotated 90 degrees clockwise.</para>
-        /// <para>2 - Rotated 180 degrees clockwise.</para>
-        /// <para>3 - Rotated 270 degrees clockwise.</para>
-        /// </param>
-        /// <returns></returns>
         public void SetRotation(int rotation)
         {
-            Document.Dispatcher.SyncExec(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
-        }
-
-        /// <summary>
-        /// Rotates the page
-        /// </summary>
-        /// <returns>
-        /// <para>0 - No rotation.</para>
-        /// <para>1 - Rotated 90 degrees clockwise.</para>
-        /// <para>2 - Rotated 180 degrees clockwise.</para>
-        /// <para>3 - Rotated 270 degrees clockwise.</para>
-        /// </returns>
-        public Task<int> GetRotationAsync()
-        {
-            return Document.Dispatcher.QueueResult(_ => fpdf_edit.FPDFPageGetRotation(PageInstance));
+            Document.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
         }
 
         /// <summary>
@@ -63,22 +34,7 @@ namespace DtronixPdf
         /// </returns>
         public int GetRotation()
         {
-            return Document.Dispatcher.SyncExec(() => fpdf_edit.FPDFPageGetRotation(PageInstance));
-        }
-
-        /// <summary>
-        /// Rotates the page
-        /// </summary>
-        /// <param name="rotation">
-        /// <para>0 - No rotation.</para>
-        /// <para>1 - Rotated 90 degrees clockwise.</para>
-        /// <para>2 - Rotated 180 degrees clockwise.</para>
-        /// <para>3 - Rotated 270 degrees clockwise.</para>
-        /// </param>
-        /// <returns></returns>
-        public Task DeleteAsync()
-        {
-            return Document.Dispatcher.Queue(() => fpdf_edit.FPDFPageDelete(Document.Instance, InitialIndex));
+            return Document.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageGetRotation(PageInstance));
         }
 
         /// <summary>
@@ -93,7 +49,7 @@ namespace DtronixPdf
         /// <returns></returns>
         public void Delete()
         {
-            Document.Dispatcher.SyncExec(() => fpdf_edit.FPDFPageDelete(Document.Instance, InitialIndex));
+            Document.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageDelete(Document.Instance, InitialIndex));
         }
     }
 }

--- a/src/DtronixPdf/PdfPage.cs
+++ b/src/DtronixPdf/PdfPage.cs
@@ -9,7 +9,7 @@ using PDFiumCore;
 
 namespace DtronixPdf
 {
-    public partial class PdfPage : IAsyncDisposable
+    public partial class PdfPage : IAsyncDisposable, IDisposable
     {
         private readonly ThreadDispatcher _dispatcher;
         private readonly FpdfDocumentT _documentInstance;
@@ -127,6 +127,16 @@ namespace DtronixPdf
             {
                 fpdfview.FPDF_ClosePage(PageInstance);
             })).ConfigureAwait(false);
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+
+            fpdfview.FPDF_ClosePage(PageInstance);
         }
     }
 }

--- a/src/DtronixPdf/PdfPage.cs
+++ b/src/DtronixPdf/PdfPage.cs
@@ -6,17 +6,15 @@ using DtronixCommon.Threading.Dispatcher;
 using DtronixCommon.Threading.Dispatcher.Actions;
 using DtronixPdf.Actions;
 using PDFiumCore;
+using static System.Collections.Specialized.BitVector32;
 
 namespace DtronixPdf
 {
     public partial class PdfPage : IAsyncDisposable, IDisposable
     {
-        private readonly ThreadDispatcher _dispatcher;
-        private readonly FpdfDocumentT _documentInstance;
+        internal readonly PdfDocument Document;
         private readonly FpdfPageT _pageInstance;
         private bool _isDisposed = false;
-
-        public ThreadDispatcher Dispatcher => _dispatcher;
 
         public float Width { get; private set; }
         public float Height { get; private set; }
@@ -25,36 +23,65 @@ namespace DtronixPdf
 
         internal FpdfPageT PageInstance => _pageInstance;
 
-        private PdfPage(ThreadDispatcher dispatcher, FpdfDocumentT documentInstance, FpdfPageT pageInstance)
+        private PdfPage(PdfDocument document, FpdfPageT pageInstance)
         {
-            _dispatcher = dispatcher;
-            _documentInstance = documentInstance;
+            Document = document;
             _pageInstance = pageInstance;
         }
 
         internal static async Task<PdfPage> CreateAsync(
-            ThreadDispatcher dispatcher,
-            FpdfDocumentT documentInstance,
+            PdfDocument document,
             int pageIndex)
         {
-            var loadPageResult = await dispatcher.QueueResult(_ => fpdfview.FPDF_LoadPage(documentInstance, pageIndex))
+            
+            var loadPageResult = await document.Dispatcher.QueueResult(_ => fpdfview.FPDF_LoadPage(document.Instance, pageIndex))
                 .ConfigureAwait(false);
             if (loadPageResult == null)
                 throw new Exception($"Failed to open page for page index {pageIndex}.");
 
-            var page = new PdfPage(dispatcher, documentInstance, loadPageResult)
+            var page = new PdfPage(document, loadPageResult)
             {
                 InitialIndex = pageIndex
             };
 
-            var getPageSizeResult = await dispatcher.QueueResult(_ =>
+            var getPageSizeResult = await document.Dispatcher.QueueResult(_ =>
             {
                 var size = new FS_SIZEF_();
                 
-                var result = fpdfview.FPDF_GetPageSizeByIndexF(documentInstance, pageIndex, size);
+                var result = fpdfview.FPDF_GetPageSizeByIndexF(document.Instance, pageIndex, size);
 
                 return result == 0 ? null : size;
             }).ConfigureAwait(false);
+
+            if (getPageSizeResult == null)
+                throw new Exception($"Could not retrieve page size for page index {pageIndex}.");
+            page.Width = getPageSizeResult.Width;
+            page.Height = getPageSizeResult.Height;
+
+            return page;
+        }
+
+        internal static PdfPage Create(
+            PdfDocument document,
+            int pageIndex)
+        {
+            var loadPageResult = document.Dispatcher.SyncExec(() => fpdfview.FPDF_LoadPage(document.Instance, pageIndex));
+            if (loadPageResult == null)
+                throw new Exception($"Failed to open page for page index {pageIndex}.");
+
+            var page = new PdfPage(document, loadPageResult)
+            {
+                InitialIndex = pageIndex
+            };
+
+            var getPageSizeResult = document.Dispatcher.SyncExec(() =>
+            {
+                var size = new FS_SIZEF_();
+
+                var result = fpdfview.FPDF_GetPageSizeByIndexF(document.Instance, pageIndex, size);
+
+                return result == 0 ? null : size;
+            });
 
             if (getPageSizeResult == null)
                 throw new Exception($"Could not retrieve page size for page index {pageIndex}.");
@@ -73,15 +100,16 @@ namespace DtronixPdf
             if (_isDisposed)
                 throw new ObjectDisposedException(nameof(PdfPage));
 
-            return await _dispatcher.QueueResult(
-                new RenderPageAction(
-                    _dispatcher,
-                    PageInstance,
-                    scale,
-                    new Boundary(0,0, Width, Height),
-                    flags,
-                    argbBackground,
-                    cancellationToken)).ConfigureAwait(false);
+            var action = new RenderPageAction(
+                Document.Dispatcher,
+                PageInstance,
+                scale,
+                new Boundary(0, 0, Width, Height),
+                flags,
+                argbBackground,
+                cancellationToken);
+
+            return await Document.Dispatcher.QueueResult(action).ConfigureAwait(false);
         }
 
         public async Task<PdfBitmap> RenderAsync(
@@ -97,15 +125,62 @@ namespace DtronixPdf
             if (viewport.IsEmpty)
                 throw new ArgumentException("Viewport is empty", nameof(viewport));
 
-            return await _dispatcher.QueueResult(
-                new RenderPageAction(
-                    _dispatcher,
-                    PageInstance,
-                    scale,
-                    viewport,
-                    flags,
-                    argbBackground,
-                    cancellationToken)).ConfigureAwait(false);
+            var action = new RenderPageAction(
+                Document.Dispatcher,
+                PageInstance,
+                scale,
+                viewport,
+                flags,
+                argbBackground,
+                cancellationToken);
+
+            return await Document.Dispatcher.QueueResult(action).ConfigureAwait(false);
+        }
+
+        public PdfBitmap Render(
+            float scale,
+            uint? argbBackground,
+            RenderFlags flags = RenderFlags.RenderAnnotations,
+            CancellationToken cancellationToken = default)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(nameof(PdfPage));
+
+            var action = new RenderPageAction(
+                Document.Dispatcher,
+                PageInstance,
+                scale,
+                new Boundary(0, 0, Width, Height),
+                flags,
+                argbBackground,
+                cancellationToken);
+
+            return Document.Dispatcher.SyncExec(() => action.ExecuteSync(default));
+        }
+
+        public PdfBitmap Render(
+            float scale,
+            uint? argbBackground,
+            Boundary viewport,
+            RenderFlags flags = RenderFlags.RenderAnnotations,
+            CancellationToken cancellationToken = default)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(nameof(PdfPage));
+
+            if (viewport.IsEmpty)
+                throw new ArgumentException("Viewport is empty", nameof(viewport));
+
+            var action = new RenderPageAction(
+                Document.Dispatcher,
+                PageInstance,
+                scale,
+                viewport,
+                flags,
+                argbBackground,
+                cancellationToken);
+
+            return Document.Dispatcher.SyncExec(() => action.ExecuteSync(default));
         }
 
         public async Task<PdfBitmap> RenderAsync(RenderPageAction action)
@@ -113,7 +188,16 @@ namespace DtronixPdf
             if (_isDisposed)
                 throw new ObjectDisposedException(nameof(PdfPage));
             
-            return await _dispatcher.QueueResult(action).ConfigureAwait(false);
+            return await Document.Dispatcher.QueueResult(action).ConfigureAwait(false);
+        }
+
+        public PdfBitmap Render(RenderPageAction action)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(nameof(PdfPage));
+
+            return Document.Dispatcher.SyncExec(() => action.ExecuteSync(CancellationToken.None));
+
         }
 
         public async ValueTask DisposeAsync()
@@ -123,10 +207,9 @@ namespace DtronixPdf
 
             _isDisposed = true;
 
-            await _dispatcher.Queue(new SimpleMessagePumpAction(() =>
-            {
-                fpdfview.FPDF_ClosePage(PageInstance);
-            })).ConfigureAwait(false);
+            await Document.Dispatcher
+                .Queue(new SimpleMessagePumpAction(() => fpdfview.FPDF_ClosePage(PageInstance)))
+                .ConfigureAwait(false);
         }
 
         public void Dispose()
@@ -136,7 +219,7 @@ namespace DtronixPdf
 
             _isDisposed = true;
 
-            fpdfview.FPDF_ClosePage(PageInstance);
+            Document.Dispatcher.SyncExec(() => fpdfview.FPDF_ClosePage(PageInstance));
         }
     }
 }

--- a/src/DtronixPdf/PdfPage.cs
+++ b/src/DtronixPdf/PdfPage.cs
@@ -10,7 +10,7 @@ using static System.Collections.Specialized.BitVector32;
 
 namespace DtronixPdf
 {
-    public partial class PdfPage : IAsyncDisposable, IDisposable
+    public partial class PdfPage : IDisposable
     {
         internal readonly PdfDocument Document;
         private readonly FpdfPageT _pageInstance;
@@ -198,18 +198,6 @@ namespace DtronixPdf
 
             return Document.Dispatcher.SyncExec(() => action.ExecuteSync(CancellationToken.None));
 
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            if (_isDisposed)
-                return;
-
-            _isDisposed = true;
-
-            await Document.Dispatcher
-                .Queue(new SimpleMessagePumpAction(() => fpdfview.FPDF_ClosePage(PageInstance)))
-                .ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/src/DtronixPdf/PdfRenderedPage.cs
+++ b/src/DtronixPdf/PdfRenderedPage.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace DtronixPdf
 {
-    public class PdfRenderedPage : IAsyncDisposable
+    public class PdfRenderedPage : IDisposable
     {
         public PdfBitmap PdfBitmap { get; }
         //public BitmapSource BitmapSource { get; }
@@ -24,9 +24,9 @@ namespace DtronixPdf
                 pdfBitmap.Stride);*/
         }
 
-        public async ValueTask DisposeAsync()
+        public void Dispose()
         {
-            await PdfBitmap.DisposeAsync().ConfigureAwait(false);
+            PdfBitmap?.Dispose();
         }
     }
 }

--- a/src/DtronixPdf/PdfThreadDispatcher.cs
+++ b/src/DtronixPdf/PdfThreadDispatcher.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DtronixCommon.Threading.Dispatcher;
+
+namespace DtronixPdf
+{
+    public class PdfThreadDispatcher : ThreadDispatcher
+    {
+        public readonly SemaphoreSlim Semaphore;
+
+        public PdfThreadDispatcher(int threadCount) : this(new ThreadDispatcherConfiguration()
+        {
+            ThreadCount = threadCount
+        })
+        {
+
+        }
+
+        public PdfThreadDispatcher(ThreadDispatcherConfiguration configs) 
+            : base(configs)
+        {
+            Semaphore = new SemaphoreSlim(configs.ThreadCount);
+            this.DispatcherExecutionWrapper = SyncExec;
+        }
+
+        public void SyncExec(Action action)
+        {
+            try
+            {
+                Semaphore.Wait();
+                action();
+            }
+            finally
+            {
+                Semaphore.Release();
+            }
+        }
+
+        public T SyncExec<T>(Func<T> function)
+        {
+            try
+            {
+                Semaphore.Wait();
+                return function();
+            }
+            finally
+            {
+                Semaphore.Release();
+            }
+        }
+    }
+}

--- a/src/DtronixPdfBenchmark/Program.cs
+++ b/src/DtronixPdfBenchmark/Program.cs
@@ -36,7 +36,7 @@ namespace DtronixPdfBenchmark
 
             for (int i = 1; i < iterations; i++)
             {
-                await using var page = await document.GetPageAsync(0);
+                using var page = await document.GetPageAsync(0);
                 
                 float scale = i * 0.25f;
                 Point center = new Point(0, 0);
@@ -59,7 +59,7 @@ namespace DtronixPdfBenchmark
             }
 
             sw.Stop();
-            await document.DisposeAsync();
+            document.Dispose();
 
             Console.WriteLine($"Rendering {TestPdf} Complete");
         }
@@ -72,8 +72,8 @@ namespace DtronixPdfBenchmark
 
             for (int i = 1; i < iterations; i++)
             {
-                await using var document = await PdfDocument.LoadAsync(TestPdf, null);
-                await using var page = await document.GetPageAsync(0);
+                using var document = await PdfDocument.LoadAsync(TestPdf, null);
+                using var page = await document.GetPageAsync(0);
 
                 Console.WriteLine($"{sw.ElapsedMilliseconds:##,###} Milliseconds");
                 sw.Restart();

--- a/src/DtronixPdfBenchmark/Program.cs
+++ b/src/DtronixPdfBenchmark/Program.cs
@@ -19,8 +19,8 @@ namespace DtronixPdfBenchmark
             if (!Directory.Exists("output"))
                 Directory.CreateDirectory("output");
 
-            await RenderViewportScaling();
-            await OpenAndCloseBenchmark();
+            RenderViewportScaling();
+            OpenAndCloseBenchmark();
 
 
             Console.ReadLine();
@@ -29,31 +29,31 @@ namespace DtronixPdfBenchmark
         static async Task RenderViewportScaling()
         {
             Console.WriteLine($"RenderViewport Benchmark {TestPdf}");
-            var document = await PdfDocument.LoadAsync(TestPdf, null);
+            var document = PdfDocument.Load(TestPdf, null);
 
             sw.Restart();
             var iterations = 25;
 
             for (int i = 1; i < iterations; i++)
             {
-                using var page = await document.GetPageAsync(0);
+                using var page = document.GetPage(0);
                 
                 float scale = i * 0.25f;
                 Point center = new Point(0, 0);
                 Size size = new Size(1920, 1080);
 
                 var viewport = new Boundary(
-                    (int)((page.Width / 2 - size.Width / 2 + center.X) * scale + size.Width / 2 * (scale - 1)),
-                    (int)((page.Height / 2 - size.Height / 2 - center.Y) * scale + size.Height / 2 * (scale - 1)),
-                    size.Width,
-                    size.Height);
+                    0, 
+                    0,
+                    1920,
+                    1080);
 
 
-                await using var result = await page.RenderAsync(
+                using var result = page.Render(
                     scale,
                     Color.White.ToPixel<Argb32>().Argb,
                     viewport);
-                await result.GetImage().SaveAsPngAsync($"output/{TestPdf}-{i}.png");
+                result.GetImage().SaveAsPng($"output/{TestPdf}-{i}.png");
                 Console.WriteLine($"{sw.ElapsedMilliseconds:##,###} Milliseconds");
                 sw.Restart();
             }
@@ -72,8 +72,8 @@ namespace DtronixPdfBenchmark
 
             for (int i = 1; i < iterations; i++)
             {
-                using var document = await PdfDocument.LoadAsync(TestPdf, null);
-                using var page = await document.GetPageAsync(0);
+                using var document = PdfDocument.Load(TestPdf, null);
+                using var page = document.GetPage(0);
 
                 Console.WriteLine($"{sw.ElapsedMilliseconds:##,###} Milliseconds");
                 sw.Restart();
@@ -86,18 +86,18 @@ namespace DtronixPdfBenchmark
 
         static async Task ImportTests()
         {
-            var drawing = await PdfDocument.LoadAsync("drawing.pdf", null);
-            var testDocument = await PdfDocument.LoadAsync("testdoc1.pdf", null);
+            var drawing = PdfDocument.Load("drawing.pdf", null);
+            var testDocument = PdfDocument.Load("testdoc1.pdf", null);
 
-            var newDocument = await PdfDocument.CreateAsync();
+            var newDocument = PdfDocument.Create();
 
-            await newDocument.ImportPagesAsync(drawing, "1", 0);
-            await newDocument.ImportPagesAsync(testDocument, null, 1);
-            await newDocument.ImportPagesAsync(drawing, "1", 2);
+            newDocument.ImportPages(drawing, "1", 0);
+            newDocument.ImportPages(testDocument, null, 1);
+            newDocument.ImportPages(drawing, "1", 2);
 
-            var page = await newDocument.GetPageAsync(1);
+            var page = newDocument.GetPage(1);
 
-            await newDocument.SaveAsync("output/importtests.pdf");
+            newDocument.Save("output/importtests.pdf");
 
         }
     }


### PR DESCRIPTION
#### Changes
- Removed all asynchronous methods as all the Pdfium code is already synchronous.
- RenderPageAction is now a public action and can be passed to the new PdfPage.Render method.
- OffsetX, OffsetY and Flags are now properties on the RenderPageAction class.
