### PR TITLE
Feature Request: Add GetText method to PdfPage

### DIFF
--- a/src/DtronixPdf.Tests/PdfPageTests.cs
+++ b/src/DtronixPdf.Tests/PdfPageTests.cs
@@ -46,5 +46,16 @@ namespace DtronixPdf.Tests
             page.SetRotation(1);
             Assert.AreEqual(1, page.GetRotation());
         }
+
+        [Test]
+        public void GetTextReturnsText()
+        {
+            using var document = PdfDocument.Load("TestPdf.pdf", null);
+            using var page = document.GetPage(0);
+
+            string actual = page.GetText(0, 150, page.Width, 500);
+            Assert.AreEqual("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                actual);
+        }
     }
 }

--- a/src/DtronixPdf/PdfPage.cs
+++ b/src/DtronixPdf/PdfPage.cs
@@ -168,7 +168,7 @@ namespace DtronixPdf
             if (_isDisposed)
                 throw new ObjectDisposedException(nameof(PdfPage));
 
-            return Document.Synchronizer.SyncExec(() =>
+            return PdfiumManager.Default.Synchronizer.SyncExec(() =>
             {
                 var textPage = fpdf_text.FPDFTextLoadPage(_pageInstance);
                 if (textPage.__Instance.ToInt64() == IntPtr.Zero)
@@ -184,12 +184,12 @@ namespace DtronixPdf
                     if (length <= 0)
                         return string.Empty;
 
-                    var buffer = new ushort[length];
+                    var buffer = GC.AllocateArray<ushort>(length, true);
 
                     // Extract the text into the buffer
                     fpdf_text.FPDFTextGetBoundedText(textPage, x, y, x2, y2, ref buffer[0], length);
 
-                    return Encoding.Unicode.GetString(MemoryMarshal.AsBytes(buffer.AsSpan()).ToArray());
+                    return Encoding.Unicode.GetString(MemoryMarshal.AsBytes(buffer.AsSpan()));
                 }
                 finally
                 {

--- a/src/DtronixPdf/PdfPage.cs
+++ b/src/DtronixPdf/PdfPage.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Text;
 using System.Threading;
 using PDFiumCore;
 
@@ -158,6 +161,41 @@ namespace DtronixPdf
             {
 
             }
+        }
+
+        public string GetText(double x, double y, double width, double height)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(nameof(PdfPage));
+
+            return Document.Synchronizer.SyncExec(() =>
+            {
+                var textPage = fpdf_text.FPDFTextLoadPage(_pageInstance);
+                if (textPage.__Instance.ToInt64() == IntPtr.Zero)
+                    throw new InvalidOperationException("Failed to load text page.");
+
+                try
+                {
+                    double x2 = x + width;
+                    double y2 = y + height;
+
+                    // First call to get the required buffer length
+                    int length = fpdf_text.FPDFTextGetBoundedText(textPage, x, y, x2, y2, ref Unsafe.NullRef<ushort>(), 0);
+                    if (length <= 0)
+                        return string.Empty;
+
+                    var buffer = new ushort[length];
+
+                    // Extract the text into the buffer
+                    fpdf_text.FPDFTextGetBoundedText(textPage, x, y, x2, y2, ref buffer[0], length);
+
+                    return Encoding.Unicode.GetString(MemoryMarshal.AsBytes(buffer.AsSpan()).ToArray());
+                }
+                finally
+                {
+                    fpdf_text.FPDFTextClosePage(textPage);
+                }
+            });
         }
 
         public void Dispose()


### PR DESCRIPTION
This commit introduces the GetText method in the PdfPage class, allowing users to extract text from a specified rectangular area of a PDF page. The method leverages FPDFTextGetBoundedText for efficient text retrieval.

To ensure the functionality works as expected, a corresponding test, GetTextReturnsText, has been added to PdfPageTests.

Use Cases:

1. Extracting specific sections of text from a PDF, such as table cells or content within a defined region.
  - My primary use case is for https://github.com/majorsilence/gtk-sharp-pdf-widget and potential future inclusion in a new pdf viewer within https://github.com/majorsilence/My-FyiReporting
3. Automating document parsing workflows where text from a specific area needs to be processed.
2. Supporting features like data extraction, text validation, or annotations tied to bounded regions in PDFs.