### PR TITLE
FIX: Thread Safety

### DIFF
--- a/src/DtronixPdf.props
+++ b/src/DtronixPdf.props
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Dtronix</Company>
     <Product>Dtronix PDF</Product>
-    <Copyright>Copyright © Dtronix 2024</Copyright>
+    <Copyright>Copyright © Dtronix 2025</Copyright>
     <Authors>DJGosnell</Authors>
     <PackageProjectUrl>https://github.com/Dtronix/DtronixPdf</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Dtronix/DtronixPdf</RepositoryUrl>

--- a/src/DtronixPdf/DtronixPdf.csproj
+++ b/src/DtronixPdf/DtronixPdf.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\DtronixPdf.props" />
   <PropertyGroup>
     <Description>Tool to view and perform common modifications to PDFs. Based on PDFium.</Description>
-    <Version>1.2.1.0</Version>
+    <Version>1.3.0.0</Version>
   </PropertyGroup>
 	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
@@ -16,6 +16,6 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="PDFiumCore" Version="130.0.6693" />
+		<PackageReference Include="PDFiumCore" Version="134.0.6982" />
 	</ItemGroup>
 </Project>

--- a/src/DtronixPdf/PdfActionSynchronizer.cs
+++ b/src/DtronixPdf/PdfActionSynchronizer.cs
@@ -6,34 +6,41 @@ namespace DtronixPdf
     public class PdfActionSynchronizer
     {
         public readonly SemaphoreSlim Semaphore = new SemaphoreSlim(1, 1);
+        private const int Timeout = 60_000;
 
         public void SyncExec(Action action)
         {
+            bool acquired = false;
             try
             {
-                Semaphore.Wait();
+                Semaphore.Wait(Timeout);
+                acquired = true;
                 action();
                 Semaphore.Release();
             }
             catch
             {
-                Semaphore.Release();
+                if(acquired)
+                    Semaphore.Release();
                 throw;
             }
         }
 
         public T SyncExec<T>(Func<T> function)
         {
+            bool acquired = false;
             try
             {
-                Semaphore.Wait();
+                Semaphore.Wait(Timeout);
+                acquired = true;
                 var result = function();
                 Semaphore.Release();
                 return result;
             }
             catch
             {
-                Semaphore.Release();
+                if (acquired)
+                    Semaphore.Release();
                 throw;
             }
         }

--- a/src/DtronixPdf/PdfBitmap.cs
+++ b/src/DtronixPdf/PdfBitmap.cs
@@ -8,8 +8,6 @@ namespace DtronixPdf
     {
         private readonly FpdfBitmapT _pdfBitmap;
 
-        private readonly PdfActionSynchronizer _synchronizer;
-
         public float Scale { get; }
 
         /// <summary>
@@ -31,12 +29,10 @@ namespace DtronixPdf
         /// Only call within the synchronizer since dll calls are made.
         /// </summary>
         /// <param name="pdfBitmap"></param>
-        /// <param name="synchronizer"></param>
         /// <param name="scale"></param>
         /// <param name="viewport">MinX, MinY, MaxX, MaxY</param>
         internal PdfBitmap(
             FpdfBitmapT pdfBitmap,
-            PdfActionSynchronizer synchronizer,
             float scale,
             Vector128<float> viewport)
         {
@@ -45,7 +41,6 @@ namespace DtronixPdf
             Width = (int)viewport.GetWidth();
             Height = (int)viewport.GetHeight();
             Pointer = fpdfview.FPDFBitmapGetBuffer(_pdfBitmap);
-            _synchronizer = synchronizer;
             Scale = scale;
             Viewport = viewport;
         }
@@ -57,7 +52,7 @@ namespace DtronixPdf
 
             IsDisposed = true;
 
-            _synchronizer.SyncExec(() => fpdfview.FPDFBitmapDestroy(_pdfBitmap));
+            PdfiumManager.Default.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapDestroy(_pdfBitmap));
         }
     }
 }

--- a/src/DtronixPdf/PdfPage.Edit.cs
+++ b/src/DtronixPdf/PdfPage.Edit.cs
@@ -17,7 +17,7 @@ namespace DtronixPdf
         /// <returns></returns>
         public void SetRotation(int rotation)
         {
-            Document.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
+            PdfiumManager.Default.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageSetRotation(PageInstance, rotation));
         }
 
         /// <summary>
@@ -31,22 +31,16 @@ namespace DtronixPdf
         /// </returns>
         public int GetRotation()
         {
-            return Document.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageGetRotation(PageInstance));
+            return PdfiumManager.Default.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageGetRotation(PageInstance));
         }
 
+
         /// <summary>
-        /// Rotates the page
+        /// Deletes the page.
         /// </summary>
-        /// <param name="rotation">
-        /// <para>0 - No rotation.</para>
-        /// <para>1 - Rotated 90 degrees clockwise.</para>
-        /// <para>2 - Rotated 180 degrees clockwise.</para>
-        /// <para>3 - Rotated 270 degrees clockwise.</para>
-        /// </param>
-        /// <returns></returns>
         public void Delete()
         {
-            Document.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageDelete(Document.Instance, InitialIndex));
+            PdfiumManager.Default.Synchronizer.SyncExec(() => fpdf_edit.FPDFPageDelete(Document.Instance, InitialIndex));
         }
     }
 }

--- a/src/DtronixPdf/PdfPage.cs
+++ b/src/DtronixPdf/PdfPage.cs
@@ -28,7 +28,7 @@ namespace DtronixPdf
             PdfDocument document,
             int pageIndex)
         {
-            var loadPageResult = document.Synchronizer.SyncExec(() => fpdfview.FPDF_LoadPage(document.Instance, pageIndex));
+            var loadPageResult = PdfiumManager.Default.Synchronizer.SyncExec(() => fpdfview.FPDF_LoadPage(document.Instance, pageIndex));
             if (loadPageResult == null)
                 throw new Exception($"Failed to open page for page index {pageIndex}.");
 
@@ -37,7 +37,7 @@ namespace DtronixPdf
                 InitialIndex = pageIndex
             };
 
-            var getPageSizeResult = document.Synchronizer.SyncExec(() =>
+            var getPageSizeResult = PdfiumManager.Default.Synchronizer.SyncExec(() =>
             {
                 var size = new FS_SIZEF_();
 
@@ -87,7 +87,7 @@ namespace DtronixPdf
             {
                 config.CancellationToken.ThrowIfCancellationRequested();
 
-                bitmap = Document.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapCreateEx(
+                bitmap = PdfiumManager.Default.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapCreateEx(
                     viewportWidthInt,
                     viewportHeightInt,
                     (int)FPDFBitmapFormat.BGRA,
@@ -101,7 +101,7 @@ namespace DtronixPdf
 
                 if (config.BackgroundColor.HasValue)
                 {
-                    Document.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapFillRect(
+                    PdfiumManager.Default.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapFillRect(
                         bitmap,
                         0,
                         0,
@@ -133,24 +133,24 @@ namespace DtronixPdf
                     F = config.OffsetY
                 };
 
-                Document.Synchronizer.SyncExec(() =>
+                PdfiumManager.Default.Synchronizer.SyncExec(() =>
                     fpdfview.FPDF_RenderPageBitmapWithMatrix(bitmap, _pageInstance, matrix, clipping,
                         (int)config.Flags));
 
                 config.CancellationToken.ThrowIfCancellationRequested();
 
-                return new PdfBitmap(bitmap, Document.Synchronizer, config.Scale, config.Viewport);
+                return new PdfBitmap(bitmap, config.Scale, config.Viewport);
             }
             catch (OperationCanceledException)
             {
                 if (bitmap != null)
-                    Document.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapDestroy(bitmap));
+                    PdfiumManager.Default.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapDestroy(bitmap));
                 throw;
             }
             catch (Exception ex)
             {
                 if (bitmap != null)
-                    Document.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapDestroy(bitmap));
+                    PdfiumManager.Default.Synchronizer.SyncExec(() => fpdfview.FPDFBitmapDestroy(bitmap));
 
                 throw new Exception("Error rendering page. Check inner exception.", ex);
             }
@@ -167,7 +167,7 @@ namespace DtronixPdf
 
             _isDisposed = true;
 
-            Document.Synchronizer.SyncExec(() => fpdfview.FPDF_ClosePage(PageInstance));
+            PdfiumManager.Default.Synchronizer.SyncExec(() => fpdfview.FPDF_ClosePage(PageInstance));
         }
     }
 }


### PR DESCRIPTION
My initial assumption about only having to synchronize usage of individual loaded PDF documents was incorrect and I have found conncurrent usage of the PDFIum library to be completely un-safe for concurrent usage.  This PR removes any possiblity of concurrent usage.